### PR TITLE
use py.builtin._basestring for py2/3 compatibility

### DIFF
--- a/py/_path/common.py
+++ b/py/_path/common.py
@@ -382,9 +382,9 @@ newline will be removed from the end of each line. """
 
 class Visitor:
     def __init__(self, fil, rec, ignore, bf, sort):
-        if isinstance(fil, str):
+        if isinstance(fil, py.builtin._basestring):
             fil = FNMatcher(fil)
-        if isinstance(rec, str):
+        if isinstance(rec, py.builtin._basestring):
             self.rec = FNMatcher(rec)
         elif not hasattr(rec, '__call__') and rec:
             self.rec = lambda path: True
@@ -437,4 +437,3 @@ class FNMatcher:
             if not os.path.isabs(pattern):
                 pattern = '*' + path.sep + pattern
         return py.std.fnmatch.fnmatch(name, pattern)
-

--- a/testing/path/common.py
+++ b/testing/path/common.py
@@ -1,6 +1,8 @@
 import py
 import sys
 
+import pytest
+
 class CommonFSTests(object):
     def test_constructor_equality(self, path1):
         p = path1.__class__(path1)
@@ -186,9 +188,10 @@ class CommonFSTests(object):
         assert "sampledir" in l
         assert not path1.sep.join(["sampledir", "otherfile"]) in l
 
-    def test_visit_filterfunc_is_string(self, path1):
+    @pytest.mark.paramtrize('fil', ['*dir', u'*dir'])
+    def test_visit_filterfunc_is_string(self, path1, fil):
         l = []
-        for i in path1.visit('*dir'):
+        for i in path1.visit(fil):
             l.append(i.relto(path1))
         assert len(l), 2
         assert "sampledir" in l

--- a/testing/path/common.py
+++ b/testing/path/common.py
@@ -188,7 +188,9 @@ class CommonFSTests(object):
         assert "sampledir" in l
         assert not path1.sep.join(["sampledir", "otherfile"]) in l
 
-    @pytest.mark.paramtrize('fil', ['*dir', u'*dir'])
+    @pytest.mark.parametrize('fil', ['*dir', u'*dir',
+                             pytest.mark.skip("sys.version_info <"
+                                              " (3,6)")(b'*dir')])
     def test_visit_filterfunc_is_string(self, path1, fil):
         l = []
         for i in path1.visit(fil):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py26,py27,py33,py34,external
+envlist=py26,py27,py33,py34,py35,external
 # py27-xdist causes problems with svn, py25 requires virtualenv==1.9.1
 #indexserver=
 #    default=http://pypi.testrun.org


### PR DESCRIPTION
when visiting a path, check that the input values are a string in a python2/3 compatible way. See issue #81 