### PR TITLE
Make TerminalWriter.fullwidth a property

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,9 @@
 
 - fix issue70: added ability to copy all stat info in py.path.local.copy.
 
+- make TerminalWriter.fullwidth a property.  This results in the correct
+  value when the terminal gets resized.
+
 1.4.31
 ==================================================
 

--- a/py/_io/terminalwriter.py
+++ b/py/_io/terminalwriter.py
@@ -137,9 +137,18 @@ class TerminalWriter(object):
             file = colorama.AnsiToWin32(file).stream
         self.encoding = encoding or getattr(file, 'encoding', "utf-8")
         self._file = file
-        self.fullwidth = get_terminal_width()
         self.hasmarkup = should_do_markup(file)
         self._lastlen = 0
+
+    @property
+    def fullwidth(self):
+        if hasattr(self, '_terminal_width'):
+            return self._terminal_width
+        return get_terminal_width()
+
+    @fullwidth.setter
+    def fullwidth(self, value):
+        self._terminal_width = value
 
     def _escaped(self, text, esc):
         if esc and self.hasmarkup:


### PR DESCRIPTION
The terminal width might change, and then `self.fullwidth` becomes out
of sync.

E.g. pytest-sugar uses this to align the progress bars etc
(https://github.com/Frozenball/pytest-sugar/blob/2caec113d/pytest_sugar.py#L286-L287)

Ideally this might be cached until a SIGWINCH signal happens?!
