### PR TITLE
Remove support code for earlier Python 3 version in Source.compile

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 - update supported html tags to include recent additions.
   Thanks Denis Afonso for the PR.
 
+- Remove internal code in ``Source.compile`` meant to support earlier Python 3 versions that produced the side effect
+  of leaving ``None`` in ``sys.modules`` when called (see pytest-dev/pytest#2103).
+  Thanks Bruno Oliveira for the PR.
+
 1.4.32
 ====================================================================
 

--- a/py/_code/source.py
+++ b/py/_code/source.py
@@ -193,14 +193,6 @@ class Source(object):
             if flag & _AST_FLAG:
                 return co
             lines = [(x + "\n") for x in self.lines]
-            if sys.version_info[0] >= 3:
-                # XXX py3's inspect.getsourcefile() checks for a module
-                # and a pep302 __loader__ ... we don't have a module
-                # at code compile-time so we need to fake it here
-                m = ModuleType("_pycodecompile_pseudo_module")
-                py.std.inspect.modulesbyfile[filename] = None
-                py.std.sys.modules[None] = m
-                m.__loader__ = 1
             py.std.linecache.cache[filename] = (1, None, lines, filename)
             return co
 


### PR DESCRIPTION
This code leaves None in sys.modules as a side effect but is no longer needed in the Python 3 versions we support.

Applying patch from pytest-dev/pytest#2106.