### PR TITLE
Avoid using py.std to import fnmatch.

### DIFF
--- a/py/_path/common.py
+++ b/py/_path/common.py
@@ -1,6 +1,7 @@
 """
 """
 import os, sys, posixpath
+import fnmatch
 import py
 
 # Moved from local.py.
@@ -436,4 +437,4 @@ class FNMatcher:
             name = str(path) # path.strpath # XXX svn?
             if not os.path.isabs(pattern):
                 pattern = '*' + path.sep + pattern
-        return py.std.fnmatch.fnmatch(name, pattern)
+        return fnmatch.fnmatch(name, pattern)


### PR DESCRIPTION
fnmatch is used from the pytest ast hook which may trigger an import
from the import hook. This leads to endless recursion. Avoiding py.std
avoids the problem.

See https://github.com/pytest-dev/pytest/issues/2121 for more
information.