### PR TITLE
Do not include byte code in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,3 +7,4 @@ include conftest.py
 include tox.ini
 graft doc
 graft testing
+global-exclude *.pyc


### PR DESCRIPTION
The sdist tarball on pypi contains many bye code files under the testing folder. Adding a global-exclude on *.pyc makes sure that those are not included during the tarball generation