### PR TITLE
Ensure the LICENSE is included in built wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,8 @@
 [wheel]
 universal = 1
 
+[metadata]
+license_file = LICENSE
+
 [devpi:upload]
 formats=sdist.tgz,bdist_wheel


### PR DESCRIPTION
Otherwise it is not included by default as wheels do not honor the MANIFEST.in

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>