### PR TITLE
Fix fspath() for python2 unicode paths

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,8 @@
 - avoid imports in calls to py.path.local().fnmatch(). Thanks Andreas Pelme for
   the PR.
 
+- fix issue106: Naive unicode encoding when calling fspath() in python2. Thanks Tiago Nobrega for the PR.
+
 1.4.32
 ====================================================================
 

--- a/py/_path/common.py
+++ b/py/_path/common.py
@@ -379,7 +379,7 @@ newline will be removed from the end of each line. """
         return self.strpath == str(other)
 
     def __fspath__(self):
-        return str(self)
+        return self.strpath
 
 class Visitor:
     def __init__(self, fil, rec, ignore, bf, sort):

--- a/testing/path/test_local.py
+++ b/testing/path/test_local.py
@@ -143,6 +143,15 @@ class TestLocalPath(common.CommonFSTests):
     def test_eq_with_none(self, path1):
         assert path1 != None
 
+    def test_eq_non_ascii_unicode(self, path1):
+        path2 = path1.join(u'temp')
+        path3 = path1.join(u'ação')
+        path4 = path1.join(u'ディレクトリ')
+
+        assert path2 != path3
+        assert path2 != path4
+        assert path4 != path3
+
     def test_gt_with_strings(self, path1):
         path2 = path1.join('sampledir')
         path3 = str(path1.join("ttt"))
@@ -245,6 +254,12 @@ class TestLocalPath(common.CommonFSTests):
 
     def test_ensure_dirpath(self, tmpdir):
         newfile = tmpdir.join('test1','testfile')
+        t = newfile.ensure(dir=1)
+        assert t == newfile
+        assert newfile.check(dir=1)
+
+    def test_ensure_non_ascii_unicode(self, tmpdir):
+        newfile = tmpdir.join(u'ação',u'ディレクトリ')
         t = newfile.ensure(dir=1)
         assert t == newfile
         assert newfile.check(dir=1)


### PR DESCRIPTION
The previous implementation had a straight str(self.path) which fails in python2
for non-ascii paths (due to the default ascii assumed encoding). The added tests
check both `local == local` and the codepath through `ensure(dir=1)`, where the
bug was originally identified.