### PR TITLE
Fix unittest.TestCase.assertWarns error

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,8 @@
 
 - fix issue106: Naive unicode encoding when calling fspath() in python2. Thanks Tiago Nobrega for the PR.
 
+- fix issue110: unittest.TestCase.assertWarns fails with py imported.
+
 1.4.32
 ====================================================================
 

--- a/py/__init__.py
+++ b/py/__init__.py
@@ -15,6 +15,8 @@ from py import _apipkg
 # so that py.error.* instances are picklable
 import sys
 sys.modules['py.error'] = _apipkg.AliasModule("py.error", "py._error", 'error')
+import py.error  # "Dereference" it now just to be safe (issue110)
+
 
 _apipkg.initpkg(__name__, attr={'_apipkg': _apipkg}, exportdefs={
     # access to all standard lib modules

--- a/testing/root/test_error.py
+++ b/testing/root/test_error.py
@@ -35,3 +35,25 @@ def test_error_conversion_ENOTDIR(testdir):
 def test_checked_call_supports_kwargs(tmpdir):
     import tempfile
     py.error.checked_call(tempfile.mkdtemp, dir=str(tmpdir))
+
+
+try:
+    import unittest
+    unittest.TestCase.assertWarns
+except (ImportError, AttributeError):
+    pass  # required interface not available
+else:
+    import sys
+    import warnings
+
+    class Case(unittest.TestCase):
+        def test_assertWarns(self):
+            # Clear everything "py.*" from sys.modules and re-import py
+            # as a fresh start
+            for mod in tuple(sys.modules.keys()):
+                if mod and (mod == 'py' or mod.startswith('py.')):
+                    del sys.modules[mod]
+            import py
+
+            with self.assertWarns(UserWarning):
+                warnings.warn('this should work')


### PR DESCRIPTION
Fixes https://github.com/pytest-dev/py/issues/110 and https://github.com/pytest-dev/pytest/issues/1288 by magic.