### PR TITLE
readlines: use mode=r in py3

### DIFF
--- a/py/_path/common.py
+++ b/py/_path/common.py
@@ -170,11 +170,16 @@ class PathBase(object):
     def readlines(self, cr=1):
         """ read and return a list of lines from the path. if cr is False, the
 newline will be removed from the end of each line. """
+        if sys.version_info < (3, ):
+            mode = 'rU'
+        else:  # python 3 deprecates mode "U" in favor of "newline" option
+            mode = 'r'
+
         if not cr:
-            content = self.read('rU')
+            content = self.read(mode)
             return content.split('\n')
         else:
-            f = self.open('rU')
+            f = self.open(mode)
             try:
                 return f.readlines()
             finally:


### PR DESCRIPTION
This is the first commit targeting #115.
In the next few days I'll see if the tests give more warnings about mode=U and report here.