### PR TITLE
Fix make_numbered_dir on case-insensitive filesystems.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+1.4.34
+====================================================================
+
+- fix issue119 / pytest issue708 where tmpdir may fail to make numbered directories
+  when the filesystem is case-insensitive.
+
 1.4.33
 ====================================================================
 

--- a/py/__init__.py
+++ b/py/__init__.py
@@ -8,7 +8,7 @@ dictionary or an import path.
 
 (c) Holger Krekel and others, 2004-2014
 """
-__version__ = '1.4.33'
+__version__ = '1.4.34'
 
 from py import _apipkg
 

--- a/py/_path/local.py
+++ b/py/_path/local.py
@@ -10,7 +10,7 @@ from py._path import common
 from py._path.common import iswin32, fspath
 from stat import S_ISLNK, S_ISDIR, S_ISREG
 
-from os.path import abspath, normpath, isabs, exists, isdir, isfile, islink, dirname
+from os.path import abspath, normcase, normpath, isabs, exists, isdir, isfile, islink, dirname
 
 if sys.version_info > (3,0):
     def map_as_list(func, iter):
@@ -801,12 +801,13 @@ class LocalPath(FSBase):
         if rootdir is None:
             rootdir = cls.get_temproot()
 
+        nprefix = normcase(prefix)
         def parse_num(path):
             """ parse the number out of a path (if it matches the prefix) """
-            bn = path.basename
-            if bn.startswith(prefix):
+            nbasename = normcase(path.basename)
+            if nbasename.startswith(nprefix):
                 try:
-                    return int(bn[len(prefix):])
+                    return int(nbasename[len(nprefix):])
                 except ValueError:
                     pass
 
@@ -897,6 +898,7 @@ class LocalPath(FSBase):
 
         return udir
     make_numbered_dir = classmethod(make_numbered_dir)
+
 
 def copymode(src, dest):
     """ copy permission from src to dst. """

--- a/testing/path/test_local.py
+++ b/testing/path/test_local.py
@@ -399,6 +399,22 @@ class TestExecution:
             if i>=3:
                 assert not numdir.new(ext=str(i-3)).check()
 
+    def test_make_numbered_dir_case_insensitive(self, tmpdir, monkeypatch):
+        # https://github.com/pytest-dev/pytest/issues/708
+        monkeypatch.setattr(py._path.local, 'normcase', lambda path: path.lower())
+        monkeypatch.setattr(tmpdir, 'listdir', lambda: [tmpdir._fastjoin('case.0')])
+        numdir = local.make_numbered_dir(prefix='CAse.', rootdir=tmpdir,
+                                         keep=2, lock_timeout=0)
+        assert numdir.basename.endswith('.1')
+
+    def test_make_numbered_dir_case_sensitive(self, tmpdir, monkeypatch):
+        # https://github.com/pytest-dev/pytest/issues/708
+        monkeypatch.setattr(py._path.local, 'normcase', lambda path: path)
+        monkeypatch.setattr(tmpdir, 'listdir', lambda: [tmpdir._fastjoin('case.0')])
+        numdir = local.make_numbered_dir(prefix='CAse.', rootdir=tmpdir,
+                                         keep=2, lock_timeout=0)
+        assert numdir.basename.endswith('.0')
+
     def test_make_numbered_dir_NotImplemented_Error(self, tmpdir, monkeypatch):
         def notimpl(x, y):
             raise NotImplementedError(42)


### PR DESCRIPTION
See https://github.com/pytest-dev/pytest/issues/708