### PR TITLE
Remove use of `unicode` keyword in code.ExceptionInfo.__unicode__()

### DIFF
--- a/py/_code/code.py
+++ b/py/_code/code.py
@@ -419,7 +419,7 @@ class ExceptionInfo(object):
     def __unicode__(self):
         entry = self.traceback[-1]
         loc = ReprFileLocation(entry.path, entry.lineno + 1, self.exconly())
-        return unicode(loc)
+        return loc.__unicode__()
 
 
 class FormattedExcinfo(object):


### PR DESCRIPTION
When this call is attempted from python3 it will fail, so we just call `__unicode__` directly instead of via the `unicode` keyword.