### PR TITLE
Fix exception in Python 3.7 due to bad re.sub replacment escapes

### DIFF
--- a/py/_path/local.py
+++ b/py/_path/local.py
@@ -737,7 +737,7 @@ class LocalPath(FSBase):
                     except KeyError:
                         pass
                     else:
-                        paths = [re.sub('%SystemRoot%', systemroot, path)
+                        paths = [path.replace('%SystemRoot%', systemroot)
                                  for path in paths]
                 else:
                     paths = py.std.os.environ['PATH'].split(':')


### PR DESCRIPTION
Documented here: https://docs.python.org/3.7/whatsnew/3.7.html#api-and-feature-removals. Used to be a warnings and became an hard error in 3.7.

```
Traceback (most recent call last):
  File "C:\Users\Segev\prj\python\cpython\lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "C:\Users\Segev\prj\python\cpython\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "C:\Users\Segev\prj\python\twisted\venv\Scripts\tox.exe\__main__.py", line 9, in <module>
  File "c:\users\segev\prj\python\twisted\venv\lib\site-packages\tox\session.py", line 38, in main
    config = prepare(args)
  File "c:\users\segev\prj\python\twisted\venv\lib\site-packages\tox\session.py", line 26, in prepare
    config = parseconfig(args)
  File "c:\users\segev\prj\python\twisted\venv\lib\site-packages\tox\config.py", line 242, in parseconfig
    parseini(config, inipath)
  File "c:\users\segev\prj\python\twisted\venv\lib\site-packages\tox\config.py", line 790, in __init__
    self.make_envconfig(name, section, reader._subs, config)
  File "c:\users\segev\prj\python\twisted\venv\lib\site-packages\tox\config.py", line 821, in make_envconfig
    res = meth(env_attr.name, env_attr.default)
  File "c:\users\segev\prj\python\twisted\venv\lib\site-packages\tox\config.py", line 994, in getargvlist
    return _ArgvlistReader.getargvlist(self, s)
  File "c:\users\segev\prj\python\twisted\venv\lib\site-packages\tox\config.py", line 1164, in getargvlist
    commands.append(cls.processcommand(reader, current_command))
  File "c:\users\segev\prj\python\twisted\venv\lib\site-packages\tox\config.py", line 1194, in processcommand
    new_word = reader._replace(word)
  File "c:\users\segev\prj\python\twisted\venv\lib\site-packages\tox\config.py", line 1038, in _replace
    return Replacer(self, crossonly=crossonly).do_replace(value)
  File "c:\users\segev\prj\python\twisted\venv\lib\site-packages\tox\config.py", line 1058, in do_replace
    return self.RE_ITEM_REF.sub(self._replace_match, x)
  File "c:\users\segev\prj\python\twisted\venv\lib\site-packages\tox\config.py", line 1091, in _replace_match
    return self._replace_substitution(match)
  File "c:\users\segev\prj\python\twisted\venv\lib\site-packages\tox\config.py", line 1133, in _replace_substitution
    val = val()
  File "c:\users\segev\prj\python\twisted\venv\lib\site-packages\tox\config.py", line 639, in get_envsitepackagesdir
    info=self.python_info,
  File "c:\users\segev\prj\python\twisted\venv\lib\site-packages\tox\config.py", line 646, in python_info
    return self.config.interpreters.get_info(envconfig=self)
  File "c:\users\segev\prj\python\twisted\venv\lib\site-packages\tox\interpreters.py", line 28, in get_info
    executable = self.get_executable(envconfig)
  File "c:\users\segev\prj\python\twisted\venv\lib\site-packages\tox\interpreters.py", line 23, in get_executable
    exe = self.hook.tox_get_python_executable(envconfig=envconfig)
  File "c:\users\segev\prj\python\twisted\venv\lib\site-packages\pluggy.py", line 745, in __call__
    return self._hookexec(self, self._nonwrappers + self._wrappers, kwargs)
  File "c:\users\segev\prj\python\twisted\venv\lib\site-packages\pluggy.py", line 339, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "c:\users\segev\prj\python\twisted\venv\lib\site-packages\pluggy.py", line 334, in <lambda>
    _MultiCall(methods, kwargs, hook.spec_opts).execute()
  File "c:\users\segev\prj\python\twisted\venv\lib\site-packages\pluggy.py", line 614, in execute
    res = hook_impl.function(*args)
  File "c:\users\segev\prj\python\twisted\venv\lib\site-packages\tox\interpreters.py", line 135, in tox_get_python_executable
    p = py.path.local.sysfind(name)
  File "c:\users\segev\prj\python\twisted\venv\lib\site-packages\py\_path\local.py", line 741, in sysfind
    for path in paths]
  File "c:\users\segev\prj\python\twisted\venv\lib\site-packages\py\_path\local.py", line 741, in <listcomp>
    for path in paths]
  File "C:\Users\Segev\prj\python\cpython\lib\re.py", line 191, in sub
    return _compile(pattern, flags).sub(repl, string, count)
  File "C:\Users\Segev\prj\python\cpython\lib\re.py", line 300, in _subx
    template = _compile_repl(template, pattern)
  File "C:\Users\Segev\prj\python\cpython\lib\re.py", line 291, in _compile_repl
    return sre_parse.parse_template(repl, pattern)
  File "C:\Users\Segev\prj\python\cpython\lib\sre_parse.py", line 984, in parse_template
    raise s.error('bad escape %s' % this, len(this))
sre_constants.error: bad escape \W at position 2
```