### PR TITLE
py.path.local('/').join('foo') should return '/foo' not '//foo'

### DIFF
--- a/py/_path/local.py
+++ b/py/_path/local.py
@@ -333,13 +333,16 @@ class LocalPath(FSBase):
                     strargs = newargs
                     break
                 newargs.insert(0, arg)
+        # special case for when we have e.g. strpath == "/"
+        actual_sep = "" if strpath.endswith(sep) else sep
         for arg in strargs:
             arg = arg.strip(sep)
             if iswin32:
                 # allow unix style paths even on windows.
                 arg = arg.strip('/')
                 arg = arg.replace('/', sep)
-            strpath = strpath + sep + arg
+            strpath = strpath + actual_sep + arg
+            actual_sep = sep
         obj = object.__new__(self.__class__)
         obj.strpath = normpath(strpath)
         return obj

--- a/testing/path/test_local.py
+++ b/testing/path/test_local.py
@@ -790,7 +790,7 @@ class TestPOSIXLocalPath:
     def test_join_to_root(self, path1):
         root = path1.parts()[0]
         assert len(str(root)) == 1
-        assert str(root.join('a')) == '//a'  # posix allows two slashes
+        assert str(root.join('a')) == '/a'
 
     def test_join_root_to_root_with_no_abs(self, path1):
         nroot = path1.join('/')


### PR DESCRIPTION
See #84!