### PR TITLE
py.path.local('/').join('foo') should return '/foo' not '//foo'.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+1.4.34
+======
+
+- fix #127 - path.join() no longer returns double slashes in order to ease comparing
+  to avoid breaking in non-posix unix envs like cygwin
 - fix python37 compatibility of path.sysfind on windows by correctly replacing vars
 
 1.4.34

--- a/py/_path/local.py
+++ b/py/_path/local.py
@@ -333,13 +333,16 @@ class LocalPath(FSBase):
                     strargs = newargs
                     break
                 newargs.insert(0, arg)
+        # special case for when we have e.g. strpath == "/"
+        actual_sep = "" if strpath.endswith(sep) else sep
         for arg in strargs:
             arg = arg.strip(sep)
             if iswin32:
                 # allow unix style paths even on windows.
                 arg = arg.strip('/')
                 arg = arg.replace('/', sep)
-            strpath = strpath + sep + arg
+            strpath = strpath + actual_sep + arg
+            actual_sep = sep
         obj = object.__new__(self.__class__)
         obj.strpath = normpath(strpath)
         return obj

--- a/testing/path/test_local.py
+++ b/testing/path/test_local.py
@@ -790,7 +790,7 @@ class TestPOSIXLocalPath:
     def test_join_to_root(self, path1):
         root = path1.parts()[0]
         assert len(str(root)) == 1
-        assert str(root.join('a')) == '//a'  # posix allows two slashes
+        assert str(root.join('a')) == '/a'
 
     def test_join_root_to_root_with_no_abs(self, path1):
         nroot = path1.join('/')


### PR DESCRIPTION
fix #84 
fix #127 

reapplication of the original patch by @AndreasLoow