### PR TITLE
Revert "apply the xml newlines patch, fixes #85"

### DIFF
--- a/py/_xmlgen.py
+++ b/py/_xmlgen.py
@@ -237,8 +237,7 @@ class _escape:
     def __init__(self):
         self.escape = {
             u('"') : u('&quot;'), u('<') : u('&lt;'), u('>') : u('&gt;'),
-            u('&') : u('&amp;'), u("'") : u('&apos;'), u('\n') : u('&#10'),
-            u('\r') : u('&#13'),
+            u('&') : u('&amp;'), u("'") : u('&apos;'),
             }
         self.charef_rex = re.compile(u("|").join(self.escape.keys()))
 

--- a/testing/root/test_xmlgen.py
+++ b/testing/root/test_xmlgen.py
@@ -7,7 +7,7 @@ class ns(py.xml.Namespace):
     pass
 
 def test_escape():
-    uvalue = py.builtin._totext('\xc4\x85\xc4\x87\t\xe2\x82\xac\t', 'utf-8')
+    uvalue = py.builtin._totext('\xc4\x85\xc4\x87\n\xe2\x82\xac\n', 'utf-8')
     class A:
         def __unicode__(self):
             return uvalue
@@ -82,12 +82,6 @@ def test_tag_with_text_and_attributes_entity():
     assert x.attr.name == "hello & world"
     u = unicode(x)
     assert u == '<some name="hello &amp; world"/>'
-
-def test_tag_with_newline_attributes_entity():
-    x = ns.some(name="hello \r\n world")
-    assert x.attr.name == "hello \r\n world"
-    u = unicode(x)
-    assert u == '<some name="hello &#13&#10 world"/>'
 
 def test_raw():
     x = ns.some(py.xml.raw("<p>literal</p>"))


### PR DESCRIPTION
Reverts pytest-dev/py#138

it creates issues with pytest due to more escaping than necessary