### PR TITLE
also accept link files when looking for executable on Windows

### DIFF
--- a/py/_path/local.py
+++ b/py/_path/local.py
@@ -750,7 +750,9 @@ class LocalPath(FSBase):
                     paths = os.environ['PATH'].split(':')
             tryadd = []
             if iswin32:
-                tryadd += os.environ['PATHEXT'].split(os.pathsep)
+                executable_extensions = os.environ['PATHEXT'].split(os.pathsep)
+                tryadd += executable_extensions
+                tryadd += ['{}.LNK'.format(ext) for ext in executable_extensions]
             tryadd.append("")
 
             for x in paths:


### PR DESCRIPTION
these could be used to solve name clashes; e.g. installing multiple Pythons via conda - each version in installed as a separate env into its own folder; than you can expose these globally by creating symlinks from a top level