### PR TITLE
make_numbered_dir() multi-process-safe

### DIFF
--- a/py/_path/local.py
+++ b/py/_path/local.py
@@ -832,7 +832,6 @@ class LocalPath(FSBase):
 
         def atexit_remove_lockfile(lockfile):
             """ ensure lockfile is removed at process exit """
-
             mypid = os.getpid()
             def try_remove_lockfile():
                 # in a fork() situation, only the last process should
@@ -846,7 +845,6 @@ class LocalPath(FSBase):
                     lockfile.remove()
                 except py.error.Error:
                     pass
-
             atexit.register(try_remove_lockfile)
 
         # compute the maximum number currently in use with the prefix

--- a/py/_path/local.py
+++ b/py/_path/local.py
@@ -804,7 +804,8 @@ class LocalPath(FSBase):
         """ return unique directory with a number greater than the current
             maximum one.  The number is assumed to start directly after prefix.
             if keep is true directories with a number less than (maxnum-keep)
-            will be removed.
+            will be removed. If .lock files are used (lock_timeout non-zero),
+            algorithm is multi-process safe.
         """
         if rootdir is None:
             rootdir = cls.get_temproot()

--- a/py/_path/local.py
+++ b/py/_path/local.py
@@ -891,13 +891,14 @@ class LocalPath(FSBase):
 
         # prune old directories
         udir_time = get_mtime(udir)
-        if keep and lock_timeout and udir_time:
+        if keep and udir_time:
             for path in rootdir.listdir():
                 num = parse_num(path)
                 if num is not None and num <= (maxnum - keep):
                     try:
                         # try acquiring lock to remove directory as exclusive user
-                        create_lockfile(path)
+                        if lock_timeout:
+                            create_lockfile(path)
                     except (py.error.EEXIST, py.error.ENOENT):
                         path_time = get_mtime(path)
                         if not path_time:

--- a/testing/path/test_local.py
+++ b/testing/path/test_local.py
@@ -443,8 +443,8 @@ class TestExecution:
 
     def test_make_numbered_dir_multiprocess_safe(self, tmpdir):
         # https://github.com/pytest-dev/py/issues/30
-        pool = multiprocessing.Pool(10)
-        results = [pool.apply_async(batch_make_numbered_dirs, [tmpdir, 100]) for _ in range(20)]
+        pool = multiprocessing.Pool()
+        results = [pool.apply_async(batch_make_numbered_dirs, [tmpdir, 100]) for _ in range(100)]
         for r in results:
             assert r.get() == True
 

--- a/testing/path/test_local.py
+++ b/testing/path/test_local.py
@@ -43,14 +43,18 @@ def fake_fspath_obj(request):
 
 
 def batch_make_numbered_dirs(rootdir, repeats):
-    for i in range(repeats):
-        dir_ = py.path.local.make_numbered_dir(prefix='repro-', rootdir=rootdir)
-        file_ = dir_.join('foo')
-        file_.write('%s' % i)
-        actual = int(file_.read())
-        assert actual == i, 'int(file_.read()) is %s instead of %s' % (actual, i)
-        dir_.join('.lock').remove(ignore_errors=True)
-    return True
+    try:
+        for i in range(repeats):
+            dir_ = py.path.local.make_numbered_dir(prefix='repro-', rootdir=rootdir)
+            file_ = dir_.join('foo')
+            file_.write('%s' % i)
+            actual = int(file_.read())
+            assert actual == i, 'int(file_.read()) is %s instead of %s' % (actual, i)
+            dir_.join('.lock').remove(ignore_errors=True)
+        return True
+    except KeyboardInterrupt:
+        # makes sure that interrupting test session won't hang it
+        os.exit(2)
 
 
 class TestLocalPath(common.CommonFSTests):

--- a/testing/path/test_local.py
+++ b/testing/path/test_local.py
@@ -448,7 +448,7 @@ class TestExecution:
     def test_make_numbered_dir_multiprocess_safe(self, tmpdir):
         # https://github.com/pytest-dev/py/issues/30
         pool = multiprocessing.Pool()
-        results = [pool.apply_async(batch_make_numbered_dirs, [tmpdir, 100]) for _ in range(100)]
+        results = [pool.apply_async(batch_make_numbered_dirs, [tmpdir, 100]) for _ in range(20)]
         for r in results:
             assert r.get() == True
 

--- a/testing/path/test_local.py
+++ b/testing/path/test_local.py
@@ -442,6 +442,7 @@ class TestExecution:
         assert x.check()
 
     def test_make_numbered_dir_multiprocess_safe(self, tmpdir):
+        # https://github.com/pytest-dev/py/issues/30
         pool = multiprocessing.Pool(10)
         results = [pool.apply_async(batch_make_numbered_dirs, [tmpdir, 100]) for _ in range(20)]
         for r in results:

--- a/testing/path/test_local.py
+++ b/testing/path/test_local.py
@@ -6,9 +6,9 @@ import py
 import pytest
 import os
 import sys
+import multiprocessing
 from py.path import local
 import common
-import multiprocessing
 
 failsonjython = py.test.mark.xfail("sys.platform.startswith('java')")
 failsonjywin32 = py.test.mark.xfail(
@@ -364,6 +364,7 @@ class TestExecutionOnWindows:
         h = tmpdir.ensure("hello.bat")
         x = py.path.local.sysfind("hello")
         assert x == h
+
 
 class TestExecution:
     pytestmark = skiponwin32


### PR DESCRIPTION
Solves: https://github.com/pytest-dev/py/issues/30

Patch uses ".lock" file as means to gain exclusive access to directory to use or to remove. Both _user_ and _remover_ race to create exclusively ".lock" files in directories starting with "prefix". If _user_ wins, directory shall not be removed during usage. If _remover_ wins, directory shall be "removed atomically", i.e. renamed, so that following race condition doesn't happen: 1) two _removers_ pass condition for removing directory, 2) first is preempted, 3) second removes it, 4) _user_ creates new directory with the same name, 5) first _remover_ removes _user_'s directory.

Patch introduces new dependencies to code: uuid, and to tests: multiprocessing. Both can be found in stdlib as early as 2.6.

Tests which passed at time of forking pass still, one which failed fails still:
`testing/path/test_svnauth.py::TestSvnWCAuthFunctional::()::test_switch`