### PR TITLE
add TerminalWriter.chars_on_current_line read-only property

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,8 @@
 - turn iniconfig and apipkg into vendored packages and ease de-vendoring for distributions
 - fix #68 remove invalid py.test.ensuretemp references
 - fix #25 - deprecate path.listdir(sort=callable)
+- add ``TerminalWriter.chars_on_current_line`` read-only property that tracks how many characters
+  have been written to the current line.
 
 1.4.34
 ====================================================================

--- a/py/_io/terminalwriter.py
+++ b/py/_io/terminalwriter.py
@@ -139,6 +139,7 @@ class TerminalWriter(object):
         self._file = file
         self.hasmarkup = should_do_markup(file)
         self._lastlen = 0
+        self._chars_on_current_line = 0
 
     @property
     def fullwidth(self):
@@ -149,6 +150,19 @@ class TerminalWriter(object):
     @fullwidth.setter
     def fullwidth(self, value):
         self._terminal_width = value
+
+    @property
+    def chars_on_current_line(self):
+        """Return the number of characters written so far in the current line.
+
+        Please note that this count does not produce correct results after a reline() call,
+        see #164.
+
+        .. versionadded:: 1.5.0
+
+        :rtype: int
+        """
+        return self._chars_on_current_line
 
     def _escaped(self, text, esc):
         if esc and self.hasmarkup:
@@ -200,11 +214,21 @@ class TerminalWriter(object):
         if msg:
             if not isinstance(msg, (bytes, text)):
                 msg = text(msg)
+
+            self._update_chars_on_current_line(msg)
+
             if self.hasmarkup and kw:
                 markupmsg = self.markup(msg, **kw)
             else:
                 markupmsg = msg
             write_out(self._file, markupmsg)
+
+    def _update_chars_on_current_line(self, text):
+        fields = text.rsplit('\n', 1)
+        if '\n' in text:
+            self._chars_on_current_line = len(fields[-1])
+        else:
+            self._chars_on_current_line += len(fields[-1])
 
     def line(self, s='', **kw):
         self.write(s, **kw)
@@ -229,6 +253,9 @@ class Win32ConsoleWriter(TerminalWriter):
         if msg:
             if not isinstance(msg, (bytes, text)):
                 msg = text(msg)
+
+            self._update_chars_on_current_line(msg)
+
             oldcolors = None
             if self.hasmarkup and kw:
                 handle = GetStdHandle(STD_OUTPUT_HANDLE)

--- a/testing/io_/test_terminalwriter.py
+++ b/testing/io_/test_terminalwriter.py
@@ -226,6 +226,27 @@ def test_terminal_with_callable_write_and_flush():
     assert l == set(["2"])
 
 
+def test_chars_on_current_line():
+    tw = py.io.TerminalWriter(stringio=True)
+
+    written = []
+
+    def write_and_check(s, expected):
+        tw.write(s, bold=True)
+        written.append(s)
+        assert tw.chars_on_current_line == expected
+        assert tw.stringio.getvalue() == ''.join(written)
+
+    write_and_check('foo', 3)
+    write_and_check('bar', 6)
+    write_and_check('\n', 0)
+    write_and_check('\n', 0)
+    write_and_check('\n\n\n', 0)
+    write_and_check('\nfoo', 3)
+    write_and_check('\nfbar\nhello', 5)
+    write_and_check('10', 7)
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="win32 has no native ansi")
 def test_attr_hasmarkup():
     tw = py.io.TerminalWriter(stringio=True)


### PR DESCRIPTION
As discussed in pytest-dev/pytest#2858