### PR TITLE
Fix py.log import error on Windows due to syslog

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+1.5.2
+=====
+
+- fix #169, #170: error importing py.log on Windows: no module named ``syslog``.
+
 1.5.1
 =====
 

--- a/py/__init__.py
+++ b/py/__init__.py
@@ -8,7 +8,7 @@ dictionary or an import path.
 
 (c) Holger Krekel and others, 2004-2014
 """
-__version__ = '1.5.1'
+__version__ = '1.5.2'
 
 try:
     from py._vendored_packages import apipkg

--- a/py/_log/log.py
+++ b/py/_log/log.py
@@ -16,7 +16,6 @@ XXX implement this API: (maybe put it into slogger.py?)
 """
 import py
 import sys
-import syslog
 
 
 class Message(object):
@@ -190,11 +189,18 @@ class Syslog:
 
     def __call__(self, msg):
         """ write a message to the log """
+        import syslog
         syslog.syslog(self.priority, str(msg))
 
-for _prio in "EMERG ALERT CRIT ERR WARNING NOTICE INFO DEBUG".split():
-    _prio = "LOG_" + _prio
-    try:
-        setattr(Syslog, _prio, getattr(syslog, _prio))
-    except AttributeError:
-        pass
+
+try:
+    import syslog
+except ImportError:
+    pass
+else:
+    for _prio in "EMERG ALERT CRIT ERR WARNING NOTICE INFO DEBUG".split():
+        _prio = "LOG_" + _prio
+        try:
+            setattr(Syslog, _prio, getattr(syslog, _prio))
+        except AttributeError:
+            pass

--- a/testing/log/test_log.py
+++ b/testing/log/test_log.py
@@ -1,11 +1,9 @@
 import py
-import sys
 
-import pytest
+from py._log.log import default_keywordmapper
 
 callcapture = py.io.StdCapture.call
 
-default_keywordmapper = pytest.importorskip('py._log.log.default_keywordmapper')
 
 def setup_module(mod):
     mod._oldstate = default_keywordmapper.getstate()

--- a/testing/root/test_py_imports.py
+++ b/testing/root/test_py_imports.py
@@ -4,8 +4,6 @@ import sys
 
 @py.test.mark.parametrize('name', [x for x in dir(py) if x[0] != '_'])
 def test_dir(name):
-    if name == 'log' and sys.platform.startswith('win'):
-        py.test.skip('syslog is not available on Windows')
     obj = getattr(py, name)
     if hasattr(obj, '__map__'):  # isinstance(obj, Module):
         keys = dir(obj)
@@ -54,8 +52,6 @@ def test_importall():
 
 
 def check_import(modpath):
-    if modpath == 'py._log.log' and sys.platform.startswith('win'):
-        py.test.skip('syslog is not available on Windows')
     py.builtin.print_("checking import", modpath)
     assert __import__(modpath)
 


### PR DESCRIPTION
This fixes #169 and #170 