### PR TITLE
Add note about removing 1.5.0 from PyPI to the CHANGELOG

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,10 @@
 1.5.0
 =====
 
+NOTE: **this release has been removed from PyPI** due to missing package
+      metadata which caused a number of problems to py26 and py33 users.
+      This issue was fixed in the 1.5.1 release.
+
 - python 2.6 and 3.3 are no longer supported
 - deprecate py.std and remove all internal uses
 - fix #73 turn py.error into an actual module


### PR DESCRIPTION
Ref: #170