### PR TITLE
Fix emboldening in CHANGELOG

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,8 +12,8 @@
 =====
 
 NOTE: **this release has been removed from PyPI** due to missing package
-      metadata which caused a number of problems to py26 and py33 users.
-      This issue was fixed in the 1.5.1 release.
+metadata which caused a number of problems to py26 and py33 users.
+This issue was fixed in the 1.5.1 release.
 
 - python 2.6 and 3.3 are no longer supported
 - deprecate py.std and remove all internal uses


### PR DESCRIPTION
It was being rendered weird with the bold continuing to the end of the line instead of ending at 'PyPI', this makes it into an ordinary paragraph where the bold works properly.