### PR TITLE
[WIP] Extract ExceptionContext from pytest.python_api.RaisesContext.

### DIFF
--- a/py/_code/code.py
+++ b/py/_code/code.py
@@ -794,3 +794,20 @@ def getrawcode(obj, trycall=True):
                     return x
         return obj
 
+
+class ExceptionContext(object):
+    def __init__(self, expected_exception):
+        self.expected_exception = expected_exception
+        self.excinfo = None
+
+    def __enter__(self):
+        self.excinfo = object.__new__(ExceptionInfo)
+        return self.excinfo
+
+    def __exit__(self, *tp):
+        __tracebackhide__ = True
+        self.excinfo.__init__(tp)
+        suppress_exception = issubclass(self.excinfo.type, self.expected_exception)
+        if sys.version_info[0] == 2 and suppress_exception:
+            sys.exc_clear()
+        return suppress_exception


### PR DESCRIPTION
I occasionally wish I had the interfaces that `pytest.raises` provides without the assertion logic - just the ability to test if an exception occurred and if so retains the details of that exception.

This PR extracts that functionality from pytest.

After pytest can depend on this new functionality, its implementation can be pared down to:

```
class RaisesContext(_py._code.ExceptionContext):
    def __init__(self, expected_exception, message, match_expr):
        super(RaisesContext, self).__init__(expected_exception)
        self.message = message
        self.match_expr = match_expr

    def __exit__(self, *tp):
        __tracebackhide__ = True
        if tp[0] is None:
            fail(self.message)
        suppress_exception = super(RaisesContext, self).__exit__(*tp)
        if self.match_expr and suppress_exception:
            self.excinfo.match(self.match_expr)
        return suppress_exception
```

This approach provides greater separation of responsibility and allows for greater code re-use by making the ExceptionContext available for broader use (outside of testing frameworks).

This implementation would largely if not wholly obviate [jaraco.context.ExceptionTrap](http://jaracocontext.readthedocs.io/en/latest/#jaraco.context.ExceptionTrap). In fact, I wonder if it should be named ExceptionTrap here.

I present this as a work in progress to get your initial reaction and advice on how to proceed. Is the approach attractive and viable? Do you want tests? Documentation? Changelog?