### PR TITLE
Add message about maintenance mode to path doc

### DIFF
--- a/doc/path.txt
+++ b/doc/path.txt
@@ -2,6 +2,12 @@
 py.path
 =======
 
+    **Note**: The 'py' library is in "maintenance mode" and so is not
+    recommended for new projects. Please check out
+    `pathlib <https://docs.python.org/3/library/pathlib.html>`_ or
+    `pathlib2 <https://pypi.python.org/pypi/pathlib2/>`_ for path
+    operations.
+
 The 'py' lib provides a uniform high-level api to deal with filesystems
 and filesystem-like interfaces: ``py.path``.  It aims to offer a central
 object to fs-like object trees (reading from and writing to files, adding


### PR DESCRIPTION
Users of Pytest will come to the [py.path documentation](https://py.readthedocs.io/en/latest/path.html) directly from the [Pytest tmpdir docs](https://docs.pytest.org/en/latest/tmpdir.html) without seeing any mention of "maintenance mode" on the home page of the py docs or the README on Github. This was my experience.

Therefore, I think there is benefit to adding a maintenance mode message to the `py.path` documentation, as suggested by @WoLpH in #178 . This commit adds that message.