### PR TITLE
Skip AppVeyor builds on tag pushes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,3 +24,7 @@ build: false  # Not a C# project, build stuff at the test step instead.
 
 test_script:
   - C:\Python36\python -m tox
+
+# We don't deploy anything on tags with AppVeyor, we use Travis instead, so we
+# might as well save resources
+skip_tags: true


### PR DESCRIPTION
We don't deploy anything on tags with AppVeyor, we use Travis instead, so we
might as well save resources