### PR TITLE
i18n: more accurate line width estimate...possible?

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -22,3 +22,4 @@ Jan Balster
 Grig Gheorghiu
 Bob Ippolito
 Christian Tismer
+Wim Glenn

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-1.5.5 (unreleased)
+1.6.0 (unreleased)
 ==================
 
 - add ``TerminalWriter.width_of_current_line`` (i18n version of

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+1.5.5 (unreleased)
+==================
+
+- add ``TerminalWriter.width_of_current_line`` (i18n version of
+  ``TerminalWriter.chars_on_current_line``), a read-only property
+  that tracks how wide the current line is, attempting to take
+  into account international characters in the calculation.
+
 1.5.4 (2018-06-27)
 ==================
 

--- a/py/_io/terminalwriter.py
+++ b/py/_io/terminalwriter.py
@@ -5,7 +5,7 @@ Helper functions for writing to terminals and files.
 """
 
 
-import sys, os
+import sys, os, unicodedata
 import py
 py3k = sys.version_info[0] >= 3
 from py.builtin import text, bytes
@@ -52,6 +52,21 @@ def get_terminal_width():
     return width
 
 terminal_width = get_terminal_width()
+
+char_width = {
+    'A': 1,   # "Ambiguous"
+    'F': 2,   # Fullwidth
+    'H': 1,   # Halfwidth
+    'N': 1,   # Neutral
+    'Na': 1,  # Narrow
+    'W': 2,   # Wide
+}
+
+
+def get_line_width(text):
+    text = unicodedata.normalize('NFC', text)
+    return sum(char_width.get(unicodedata.east_asian_width(c), 1) for c in text)
+
 
 # XXX unify with _escaped func below
 def ansi_print(text, esc, file=None, newline=True, flush=False):
@@ -140,6 +155,7 @@ class TerminalWriter(object):
         self.hasmarkup = should_do_markup(file)
         self._lastlen = 0
         self._chars_on_current_line = 0
+        self._width_of_current_line = 0
 
     @property
     def fullwidth(self):
@@ -163,6 +179,16 @@ class TerminalWriter(object):
         :rtype: int
         """
         return self._chars_on_current_line
+
+    @property
+    def width_of_current_line(self):
+        """Return an estimate of the width so far in the current line.
+
+        .. versionadded:: 1.5.5
+
+        :rtype: int
+        """
+        return self._width_of_current_line
 
     def _escaped(self, text, esc):
         if esc and self.hasmarkup:
@@ -223,12 +249,17 @@ class TerminalWriter(object):
                 markupmsg = msg
             write_out(self._file, markupmsg)
 
-    def _update_chars_on_current_line(self, text):
-        fields = text.rsplit('\n', 1)
-        if '\n' in text:
-            self._chars_on_current_line = len(fields[-1])
+    def _update_chars_on_current_line(self, text_or_bytes):
+        newline = b'\n' if isinstance(text_or_bytes, bytes) else '\n'
+        current_line = text_or_bytes.rsplit(newline, 1)[-1]
+        if isinstance(current_line, bytes):
+            current_line = current_line.decode('utf-8', errors='replace')
+        if newline in text_or_bytes:
+            self._chars_on_current_line = len(current_line)
+            self._width_of_current_line = get_line_width(current_line)
         else:
-            self._chars_on_current_line += len(fields[-1])
+            self._chars_on_current_line += len(current_line)
+            self._width_of_current_line += get_line_width(current_line)
 
     def line(self, s='', **kw):
         self.write(s, **kw)

--- a/py/_io/terminalwriter.py
+++ b/py/_io/terminalwriter.py
@@ -184,7 +184,7 @@ class TerminalWriter(object):
     def width_of_current_line(self):
         """Return an estimate of the width so far in the current line.
 
-        .. versionadded:: 1.5.5
+        .. versionadded:: 1.6.0
 
         :rtype: int
         """

--- a/testing/io_/test_terminalwriter_linewidth.py
+++ b/testing/io_/test_terminalwriter_linewidth.py
@@ -1,0 +1,56 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+from py._io.terminalwriter import TerminalWriter
+
+
+def test_terminal_writer_line_width_init():
+    tw = TerminalWriter()
+    assert tw.chars_on_current_line == 0
+    assert tw.width_of_current_line == 0
+
+
+def test_terminal_writer_line_width_update():
+    tw = TerminalWriter()
+    tw.write('hello world')
+    assert tw.chars_on_current_line == 11
+    assert tw.width_of_current_line == 11
+
+
+def test_terminal_writer_line_width_update_with_newline():
+    tw = TerminalWriter()
+    tw.write('hello\nworld')
+    assert tw.chars_on_current_line == 5
+    assert tw.width_of_current_line == 5
+
+
+def test_terminal_writer_line_width_update_with_wide_text():
+    tw = TerminalWriter()
+    tw.write('乇乂ㄒ尺卂 ㄒ卄丨匚匚')
+    assert tw.chars_on_current_line == 11
+    assert tw.width_of_current_line == 21  # 5*2 + 1 + 5*2
+
+
+def test_terminal_writer_line_width_update_with_wide_bytes():
+    tw = TerminalWriter()
+    tw.write('乇乂ㄒ尺卂 ㄒ卄丨匚匚'.encode('utf-8'))
+    assert tw.chars_on_current_line == 11
+    assert tw.width_of_current_line == 21
+
+
+def test_terminal_writer_line_width_composed():
+    tw = TerminalWriter()
+    text = 'café food'
+    assert len(text) == 9
+    tw.write(text)
+    assert tw.chars_on_current_line == 9
+    assert tw.width_of_current_line == 9
+
+
+def test_terminal_writer_line_width_combining():
+    tw = TerminalWriter()
+    text = 'café food'
+    assert len(text) == 10
+    tw.write(text)
+    assert tw.chars_on_current_line == 10
+    assert tw.width_of_current_line == 9


### PR DESCRIPTION
For example taking into account full width asian characters, combining accents in latin characters, etc. - it's not entirely trivial because Python module filenames can for example have accents. 

This is going to be extremely difficult to handle correctly 100% of the time, without a big performance hit, and this is just a start (plus some testing) for trying to provide a number that may hopefully be more reliable than the string length.

**pytest without this stuff:**

<img width="1025" alt="short_misaligned" src="https://user-images.githubusercontent.com/6615374/44622467-84134080-a87e-11e8-840b-13989753b4bf.png">

**pytest with this stuff:**

<img width="906" alt="short" src="https://user-images.githubusercontent.com/6615374/44622468-85dd0400-a87e-11e8-9d9a-ae527e94fd41.png">
