### PR TITLE
Correct terminal size on Windows and >= py33

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+1.7.0 (unreleased)
+==================
+
+- fix #174: use ``shutil.get_terminal_size()`` in Python 3.3+ to determine the size of the
+  terminal, which produces more accurate results than the previous method.
+
+
 1.6.0 (2018-08-27)
 ==================
 

--- a/py/_io/terminalwriter.py
+++ b/py/_io/terminalwriter.py
@@ -8,6 +8,7 @@ Helper functions for writing to terminals and files.
 import sys, os, unicodedata
 import py
 py3k = sys.version_info[0] >= 3
+py33 = sys.version_info >= (3, 3)
 from py.builtin import text, bytes
 
 win32_and_ctypes = False
@@ -24,10 +25,15 @@ if sys.platform == "win32":
 
 
 def _getdimensions():
-    import termios,fcntl,struct
-    call = fcntl.ioctl(1,termios.TIOCGWINSZ,"\000"*8)
-    height,width = struct.unpack( "hhhh", call ) [:2]
-    return height, width
+    if py33:
+        import shutil
+        size = shutil.get_terminal_size()
+        return size.lines, size.columns
+    else:
+        import termios, fcntl, struct
+        call = fcntl.ioctl(1, termios.TIOCGWINSZ, "\000" * 8)
+        height, width = struct.unpack("hhhh", call)[:2]
+        return height, width
 
 
 def get_terminal_width():

--- a/testing/io_/test_terminalwriter.py
+++ b/testing/io_/test_terminalwriter.py
@@ -1,3 +1,4 @@
+from collections import namedtuple
 
 import py
 import os, sys
@@ -10,16 +11,22 @@ def test_get_terminal_width():
     assert x == terminalwriter.get_terminal_width
 
 def test_getdimensions(monkeypatch):
-    fcntl = py.test.importorskip("fcntl")
-    import struct
-    l = []
-    monkeypatch.setattr(fcntl, 'ioctl', lambda *args: l.append(args))
-    try:
-        terminalwriter._getdimensions()
-    except (TypeError, struct.error):
-        pass
-    assert len(l) == 1
-    assert l[0][0] == 1
+    if sys.version_info >= (3, 3):
+        import shutil
+        Size = namedtuple('Size', 'lines columns')
+        monkeypatch.setattr(shutil, 'get_terminal_size', lambda: Size(60, 100))
+        assert terminalwriter._getdimensions() == (60, 100)
+    else:
+        fcntl = py.test.importorskip("fcntl")
+        import struct
+        l = []
+        monkeypatch.setattr(fcntl, 'ioctl', lambda *args: l.append(args))
+        try:
+            terminalwriter._getdimensions()
+        except (TypeError, struct.error):
+            pass
+        assert len(l) == 1
+        assert l[0][0] == 1
 
 def test_terminal_width_COLUMNS(monkeypatch):
     """ Dummy test for get_terminal_width


### PR DESCRIPTION
Closes #174 @nicoddemus 
Should work correctly but since pytest is spamming me with deprecation warnings left and right I've only tested it manually.
There are various ways of getting the correct console width pre 3.3 but this should be good enough. (Stop being stuck on ancient python versions!)