### PR TITLE
Have at least one separator in sep()

### DIFF
--- a/py/_io/terminalwriter.py
+++ b/py/_io/terminalwriter.py
@@ -227,7 +227,7 @@ class TerminalWriter(object):
             # i.e.    2 + 2*len(sepchar)*N + len(title) <= fullwidth
             #         2*len(sepchar)*N <= fullwidth - len(title) - 2
             #         N <= (fullwidth - len(title) - 2) // (2*len(sepchar))
-            N = (fullwidth - len(title) - 2) // (2*len(sepchar))
+            N = max((fullwidth - len(title) - 2) // (2*len(sepchar)), 1)
             fill = sepchar * N
             line = "%s %s %s" % (fill, title, fill)
         else:

--- a/testing/io_/test_terminalwriter.py
+++ b/testing/io_/test_terminalwriter.py
@@ -165,6 +165,12 @@ class TestTerminalWriter:
         assert len(l) == 1
         assert l[0] == "-" * 26 + " hello " + "-" * (27-win32) + "\n"
 
+    def test_sep_longer_than_width(self, tw):
+        tw.sep('-', 'a' * 10, fullwidth=5)
+        line, = tw.getlines()
+        # even though the string is wider than the line, still have a separator
+        assert line == '- aaaaaaaaaa -\n'
+
     @py.test.mark.skipif("sys.platform == 'win32'")
     def test__escaped(self, tw):
         text2 = tw._escaped("hello", (31))


### PR DESCRIPTION
Before:

```
 1 failed, 1 passed, 1 skipped, 1 deselected, 1 xfailed, 1 xpassed, 1 error in 0.04 seconds
```

After:

```
= 1 failed, 1 passed, 1 skipped, 1 deselected, 1 xfailed, 1 xpassed, 1 error in 0.04 seconds =
```

___

This is slightly selfish -- I'm doing this to make the output in this case possible to colorize for [pygments-pytest](https://github.com/asottile/pygments-pytest)