### PR TITLE
BUG FIX: Securing length calculation (line could not always be a string)

### DIFF
--- a/py/_io/terminalwriter.py
+++ b/py/_io/terminalwriter.py
@@ -237,7 +237,7 @@ class TerminalWriter(object):
         # in some situations there is room for an extra sepchar at the right,
         # in particular if we consider that with a sepchar like "_ " the
         # trailing space is not important at the end of the line
-        if len(line) + len(sepchar.rstrip()) <= fullwidth:
+        if len(str(line)) + len(sepchar.rstrip()) <= fullwidth:
             line += sepchar.rstrip()
 
         self.line(line, **kw)
@@ -278,10 +278,10 @@ class TerminalWriter(object):
         self.write(line, **kw)
         self._checkfill(line)
         self.write('\r')
-        self._lastlen = len(line)
+        self._lastlen = len(str(line))
 
     def _checkfill(self, line):
-        diff2last = self._lastlen - len(line)
+        diff2last = self._lastlen - len(str(line))
         if diff2last > 0:
             self.write(" " * diff2last)
 


### PR DESCRIPTION
Here is an example of the fixed bug (discovered using pytest). The line variable isn't always a string. To secure it, better use the `str` python's builtin function to convert whatever it is into a string.
Used python version: `python 2.7.15rc1`
```
File "/home/mehdi/python2env/bin/pytest", line 11, in <module>                                      
    sys.exit(main())                                                                                
  File "/home/mehdi/python2env/local/lib/python2.7/site-packages/_pytest/config/__init__.py", line 77, in main                                                               
    return config.hook.pytest_cmdline_main(config=config)                                              
  File "/home/mehdi/python2env/local/lib/python2.7/site-packages/pluggy/hooks.py", line 284, in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)                                          
  File "/home/mehdi/python2env/local/lib/python2.7/site-packages/pluggy/manager.py", line 67, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)                                                 
  File "/home/mehdi/python2env/local/lib/python2.7/site-packages/pluggy/manager.py", line 61, in <lambda>
    firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,                             
  File "/home/mehdi/python2env/local/lib/python2.7/site-packages/pluggy/callers.py", line 208, in _multicall
    return outcome.get_result()                                                                        
  File "/home/mehdi/python2env/local/lib/python2.7/site-packages/pluggy/callers.py", line 81, in get_result
    _reraise(*ex)  # noqa                                                                              
  File "/home/mehdi/python2env/local/lib/python2.7/site-packages/pluggy/callers.py", line 187, in _multicall
    res = hook_impl.function(*args)                                                                    
  File "/home/mehdi/python2env/local/lib/python2.7/site-packages/_pytest/main.py", line 218, in pytest_cmdline_main
    return wrap_session(config, _main)                                                                 
  File "/home/mehdi/python2env/local/lib/python2.7/site-packages/_pytest/main.py", line 211, in wrap_session
    session=session, exitstatus=session.exitstatus                                                     
  File "/home/mehdi/python2env/local/lib/python2.7/site-packages/pluggy/hooks.py", line 284, in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)                                          
  File "/home/mehdi/python2env/local/lib/python2.7/site-packages/pluggy/manager.py", line 67, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)                                                 
  File "/home/mehdi/python2env/local/lib/python2.7/site-packages/pluggy/manager.py", line 61, in <lambda>
    firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,                             
  File "/home/mehdi/python2env/local/lib/python2.7/site-packages/pluggy/callers.py", line 203, in _multicall
    gen.send(outcome)                                                                                  
  File "/home/mehdi/python2env/local/lib/python2.7/site-packages/_pytest/terminal.py", line 639, in pytest_sessionfinish
    terminalreporter=self, exitstatus=exitstatus                                                       
  File "/home/mehdi/python2env/local/lib/python2.7/site-packages/pluggy/hooks.py", line 284, in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)                                          
  File "/home/mehdi/python2env/local/lib/python2.7/site-packages/pluggy/manager.py", line 67, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)                                                 
  File "/home/mehdi/python2env/local/lib/python2.7/site-packages/pluggy/manager.py", line 61, in <lambda>
    firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,                             
  File "/home/mehdi/python2env/local/lib/python2.7/site-packages/pluggy/callers.py", line 208, in _multicall
    return outcome.get_result()                                                                        
  File "/home/mehdi/python2env/local/lib/python2.7/site-packages/pluggy/callers.py", line 81, in get_result
    _reraise(*ex)  # noqa                                                                              
  File "/home/mehdi/python2env/local/lib/python2.7/site-packages/pluggy/callers.py", line 182, in _multicall
    next(gen)  # first yield                                                                           
  File "/home/mehdi/python2env/local/lib/python2.7/site-packages/_pytest/terminal.py", line 649, in pytest_terminal_summary
    self.summary_failures()                                                                         
  File "/home/mehdi/python2env/local/lib/python2.7/site-packages/_pytest/terminal.py", line 791, in summary_failures
    self._outrep_summary(rep)                                                                       
  File "/home/mehdi/python2env/local/lib/python2.7/site-packages/_pytest/terminal.py", line 815, in _outrep_summary
    rep.toterminal(self._tw)                                                                        
  File "/home/mehdi/python2env/local/lib/python2.7/site-packages/_pytest/reports.py", line 37, in toterminal
    out.line(longrepr)                                                                              
  File "/home/mehdi/python2env/local/lib/python2.7/site-packages/py/_io/terminalwriter.py", line 272, in line
    self._checkfill(s)                                                                              
  File "/home/mehdi/python2env/local/lib/python2.7/site-packages/py/_io/terminalwriter.py", line 284, in _checkfill
    diff2last = self._lastlen - len(line)
TypeError: object of type 'ExceptionInfo' has no len()
```