### PR TITLE
path.common: handle FileNotFoundError when trying to import pathlib

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+Unreleased
+==========
+
+- handle ``FileNotFoundError`` when trying to import pathlib in ``path.common``
+  on Python 3.4 (#207).
+
 1.8.0 (2019-02-21)
 ==================
 

--- a/py/_path/common.py
+++ b/py/_path/common.py
@@ -11,6 +11,12 @@ import py
 iswin32 = sys.platform == "win32" or (getattr(os, '_name', False) == 'nt')
 
 try:
+    # FileNotFoundError might happen in py34, and is not available with py27.
+    import_errors = (ImportError, FileNotFoundError)
+except NameError:
+    import_errors = (ImportError,)
+
+try:
     from os import fspath
 except ImportError:
     def fspath(path):
@@ -35,9 +41,7 @@ except ImportError:
                 raise
             try:
                 import pathlib
-            except ImportError:
-                pass
-            except FileNotFoundError:  # Might happen in py34.
+            except import_errors:
                 pass
             else:
                 if isinstance(path, pathlib.PurePath):

--- a/py/_path/common.py
+++ b/py/_path/common.py
@@ -37,6 +37,8 @@ except ImportError:
                 import pathlib
             except ImportError:
                 pass
+            except FileNotFoundError:  # Might happen in py34.
+                pass
             else:
                 if isinstance(path, pathlib.PurePath):
                     return py.builtin.text(path)

--- a/testing/path/test_local.py
+++ b/testing/path/test_local.py
@@ -174,7 +174,31 @@ class TestLocalPath(common.CommonFSTests):
         assert path2 != path3
 
     def test_eq_with_none(self, path1):
-        assert path1 != None  # noqa
+        assert path1 != None  # noqa: E711
+
+    @pytest.mark.skipif(
+        sys.platform.startswith("win32"), reason="cannot remove cwd on Windows"
+    )
+    @pytest.mark.skipif(
+        sys.version_info < (3, 0) or sys.version_info >= (3, 5),
+        reason="only with Python 3 before 3.5"
+    )
+    def test_eq_with_none_and_custom_fspath(self, monkeypatch, path1):
+        import os
+        import shutil
+        import tempfile
+
+        d = tempfile.mkdtemp()
+        monkeypatch.chdir(d)
+        shutil.rmtree(d)
+
+        monkeypatch.delitem(sys.modules, 'pathlib', raising=False)
+        monkeypatch.setattr(sys, 'path', [''] + sys.path)
+
+        with pytest.raises(FileNotFoundError):
+            import pathlib  # noqa: F401
+
+        assert path1 != None  # noqa: E711
 
     def test_eq_non_ascii_unicode(self, path1):
         path2 = path1.join(u'temp')


### PR DESCRIPTION
Python 3.4 might raise FileNotFoundError due to `os.getcwd()` failing on
a non-existing cwd.  This is fixed in Python 3.5.

Ref: https://github.com/pytest-dev/pytest/pull/4787#issuecomment-463341251