### PR TITLE
tox: remove changedir with testenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,10 +3,9 @@
 envlist=py{27,34,35,36}-pytest{29,30,31},py37-pytest{30,31}
 
 [testenv]
-changedir=testing
 commands=
-  pip install -U .. # hande the install order fallout since pytest depends on pip
-  py.test --confcutdir=.. --junitxml={envlogdir}/junit-{envname}.xml []
+  pip install -U . # hande the install order fallout since pytest depends on pip
+  py.test --confcutdir=. --junitxml={envlogdir}/junit-{envname}.xml []
 deps=
   attrs
   pytest29: pytest~=2.9.0
@@ -32,6 +31,7 @@ commands=
 [pytest]
 rsyncdirs = conftest.py py doc testing
 addopts = -ra
+testpaths = testing
 
 [coverage:run]
 branch = 1


### PR DESCRIPTION
This is confusing in general (and does not allow to copy'n'paste paths),
and it will be easier to integrate a coverage factor after this.