### PR TITLE
Fix travis stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,10 @@ env:
     #- DEPS="pytest~=3.1.0"
 
 stages:
+  - name: test
+    if: tag IS NOT present
   - name: deploy
-    if: tag IS present
+    if: repo = pytest-dev/py AND tag IS present
 
 matrix:
   include:


### PR DESCRIPTION
As it were, "deploy" would run before "test" because it was left out of the
stages section.

Instead of running "test" and "deploy" stages on tags, to run just
"deploy"; we already require that all tests have passed before someone pushes
a tag for deployment anyway, no sense running the tests again.