### PR TITLE
Normalise path before comparing on windows

### DIFF
--- a/py/_path/local.py
+++ b/py/_path/local.py
@@ -166,9 +166,9 @@ class LocalPath(FSBase):
         return hash(self.strpath)
 
     def __eq__(self, other):
-        s1 = fspath(self)
+        s1 = normpath(fspath(self))
         try:
-            s2 = fspath(other)
+            s2 = normpath(fspath(other))
         except TypeError:
             return False
         if iswin32:


### PR DESCRIPTION
Without this change I get pytest errors on MSYS2 like this:
=================================== ERRORS ====================================
_______________ ERROR collecting test_x.py ________________
import file mismatch:
imported module 'f.test_x' has this __file__ attribute:
  C:/path/to\f\test_x.py
which is not the same as the test file we want to collect:
  C:/path/to/f/test_x.py
HINT: remove __pycache__ / .pyc files and/or use a unique basename for your test file modules
!!!!!!!!!!!!!!!!!!! Interrupted: 1 errors during collection !!!!!!!!!!!!!!!!!!!
=========================== 1 error in 0.20 seconds ===========================
Removing __pycache__ or using PYTHONDONTWRITEBYTECODE=1 doesn't help.
This seems to be the same problem as #58 was trying to fix. I've moved it to __eq__ as suggested in the original PR on bitbucket.