### PR TITLE
Fixes py.path.local.samefile in Python 3 on Windows

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,10 @@
 Unreleased
 ==========
 
-- handle ``FileNotFoundError`` when trying to import pathlib in ``path.common``
+- Handle ``FileNotFoundError`` when trying to import pathlib in ``path.common``
   on Python 3.4 (#207).
+
+- ``py.path.local.samefile`` now works correctly in Python 3 on Windows when dealing with symlinks.
 
 1.8.0 (2019-02-21)
 ==================

--- a/py/_path/local.py
+++ b/py/_path/local.py
@@ -196,8 +196,8 @@ class LocalPath(FSBase):
             other = abspath(other)
         if self == other:
             return True
-        if iswin32:
-            return False # there is no samefile
+        if not hasattr(os.path, "samefile"):
+            return False
         return py.error.checked_call(
                 os.path.samefile, self.strpath, other)
 

--- a/testing/path/test_local.py
+++ b/testing/path/test_local.py
@@ -704,6 +704,17 @@ def test_samefile(tmpdir):
         p2 = p.__class__(str(p).upper())
         assert p1.samefile(p2)
 
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="os.symlink not available")
+def test_samefile_symlink(tmpdir):
+    p1 = tmpdir.ensure("foo.txt")
+    p2 = tmpdir.join("linked.txt")
+    try:
+        os.symlink(str(p1), str(p2))
+    except OSError as e:
+        # on Windows this might fail if the user doesn't have special symlink permissions
+        pytest.skip(str(e.args[0]))
+
+    assert p1.samefile(p2)
 
 def test_listdir_single_arg(tmpdir):
     tmpdir.ensure("hello")


### PR DESCRIPTION
Python 3 on Windows contains a working implementation of os.path.samefile that should be used.

Discovered this while investigating why `test_cmdline_python_package_symlink` fails on Python 3.8 on Windows (https://github.com/pytest-dev/pytest/pull/6159).