### PR TITLE
tox: use download=true to upgrade pip/setuptools/virtualenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@
 envlist=py{27,34,35,36}-pytest{29,30,31},py37-pytest{30,31}
 
 [testenv]
+download = true
 commands=
   pip install -U . # hande the install order fallout since pytest depends on pip
   py.test --confcutdir=. --junitxml={envlogdir}/junit-{envname}.xml []


### PR DESCRIPTION
Maybe this fixes py34 on AppVeyor.

Just a test, if it does not work it's better to remove it there, and/or switch to GitHub Actions likely.

Ref: https://github.com/pytest-dev/py/pull/226