### PR TITLE
path.local: fix == doesn't imply same hash on Windows for paths which differ only by case

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+1.8.2 (TBD)
+===========
+
+- On Windows, ``py.path.local``s which differ only in case now have the same
+  Python hash value. Previously, such paths were considered equal but had
+  different hashes, which is not allowed and breaks the assumptions made by
+  dicts, sets and other users of hashes.
+
 1.8.1 (2019-12-27)
 ==================
 

--- a/py/_path/local.py
+++ b/py/_path/local.py
@@ -163,7 +163,10 @@ class LocalPath(FSBase):
             self.strpath = abspath(path)
 
     def __hash__(self):
-        return hash(self.strpath)
+        s = self.strpath
+        if iswin32:
+            s = s.lower()
+        return hash(s)
 
     def __eq__(self, other):
         s1 = fspath(self)

--- a/testing/path/test_local.py
+++ b/testing/path/test_local.py
@@ -164,6 +164,17 @@ class TestLocalPath(common.CommonFSTests):
         p = py.path.local("~", expanduser=True)
         assert p == os.path.expanduser("~")
 
+    @pytest.mark.skipif(
+        not sys.platform.startswith("win32"), reason="case insensitive only on windows"
+    )
+    def test_eq_hash_are_case_insensitive_on_windows(self):
+        a = py.path.local("/some/path")
+        b = py.path.local("/some/PATH")
+        assert a == b
+        assert hash(a) == hash(b)
+        assert a in {b}
+        assert a in {b: 'b'}
+
     def test_eq_with_strings(self, path1):
         path1 = path1.join('sampledir')
         path2 = str(path1)


### PR DESCRIPTION
This bug has potential to cause some very obscure issues on Windows, particularly for pytest which uses several dicts and sets of `py.path.local` (see [issue](https://github.com/pytest-dev/pytest/issues/7357)), and is annoying to work around, so seems worthwhile to fix at the source even if `py` is frozen.