### PR TITLE
Expand conditions for recognizing main process

### DIFF
--- a/py/_process/forkedfunc.py
+++ b/py/_process/forkedfunc.py
@@ -107,7 +107,7 @@ class ForkedFunc:
             self.tempdir.remove()
 
     def __del__(self):
-        if self.pid is not None:  # only clean up in main process
+        if not (hasattr(self, "pid") and self.pid is None):  # only clean up in main process
             self._removetemp()
 
 


### PR DESCRIPTION
Fork failures are not uncommon on Cygwin, which causes an exception in the constructor.
Unfortunately, cleaning up the partially-initialized instance calls the `__del__` method, 
which then raises another exception because `self.pid` never got set.
This change should prevent the second exception.

Another option is to change it to 
```python
if getattr(self, "pid", None) is not None:
```