### PR TITLE
svnwc: fix regular expression vulnerable to DoS in blame functionality

### DIFF
--- a/py/_path/svnwc.py
+++ b/py/_path/svnwc.py
@@ -396,7 +396,7 @@ class SvnAuth(object):
     def __str__(self):
         return "<SvnAuth username=%s ...>" %(self.username,)
 
-rex_blame = re.compile(r'\s*(\d+)\s*(\S+) (.*)')
+rex_blame = re.compile(r'\s*(\d+)\s+(\S+) (.*)')
 
 class SvnWCCommandPath(common.PathBase):
     """ path implementation offering access/modification to svn working copies.


### PR DESCRIPTION
Fixes #256.

The subpattern `\d+\s*\S+` is ambiguous which makes the pattern subject
to catastrophic backtracing given a string like `"1" * 5000`.

SVN blame output seems to always have at least one space between the
revision number and the user name, so the ambiguity can be fixed by
changing the `*` to `+`.