### PR TITLE
Replace deprecated logging.warn with .warning

### DIFF
--- a/testing/io_/test_capture.py
+++ b/testing/io_/test_capture.py
@@ -482,13 +482,13 @@ def test_capturing_and_logging_fundamentals(testdir, method):
         import py, logging
         cap = py.io.%s(out=False, in_=False)
 
-        logging.warn("hello1")
+        logging.warning("hello1")
         outerr = cap.suspend()
         print ("suspend, captured %%s" %%(outerr,))
-        logging.warn("hello2")
+        logging.warning("hello2")
 
         cap.resume()
-        logging.warn("hello3")
+        logging.warning("hello3")
 
         outerr = cap.suspend()
         print ("suspend2, captured %%s" %% (outerr,))


### PR DESCRIPTION
Like https://github.com/pytest-dev/pytest/pull/10064.

Replace `logging.warn` (deprecated in [Python 2.7, 2011](https://github.com/python/cpython/commit/04d5bc00a219860c69ea17eaa633d3ab9917409f)) with `logging.warning` (added in [Python 2.3, 2003](https://github.com/python/cpython/commit/6fa635df7aa88ae9fd8b41ae42743341316c90f7)).

* https://docs.python.org/3/library/logging.html#logging.Logger.warning
* https://github.com/python/cpython/issues/57444

