### PR TITLE
type stubs: Mark reexports using explicit reexport syntax

### DIFF
--- a/py/__init__.pyi
+++ b/py/__init__.pyi
@@ -2,11 +2,11 @@ from typing import Any
 
 # py allows to use e.g. py.path.local even without importing py.path.
 # So import implicitly.
-from . import error
-from . import iniconfig
-from . import path
-from . import io
-from . import xml
+from . import error as error
+from . import iniconfig as iniconfig
+from . import path as path
+from . import io as io
+from . import xml as xml
 
 __version__: str
 


### PR DESCRIPTION
Otherwise these reexports may not made visible from other modules, depending on the type checker configuration.

https://mypy.readthedocs.io/en/stable/config_file.html#confval-implicit_reexport