### PR TITLE
Add readthedocs configuration file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,22 @@
+version: 2
+
+python:
+   install:
+     # Install pytest first, then doc/en/requirements.txt.
+     # This order is important to honor any pins in doc/en/requirements.txt
+     # when the pinned library is also a dependency of pytest.
+     - method: pip
+       path: .
+     - requirements: doc/en/requirements.txt
+
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+  apt_packages:
+    - inkscape
+
+formats:
+  - epub
+  - pdf
+  - htmlzip

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,6 @@ python:
      # when the pinned library is also a dependency of pytest.
      - method: pip
        path: .
-     - requirements: doc/en/requirements.txt
 
 build:
   os: ubuntu-20.04

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,9 +2,6 @@ version: 2
 
 python:
    install:
-     # Install pytest first, then doc/en/requirements.txt.
-     # This order is important to honor any pins in doc/en/requirements.txt
-     # when the pinned library is also a dependency of pytest.
      - method: pip
        path: .
 


### PR DESCRIPTION
As received by email, this configuration file will become mandatory:

> The Read the Docs build system will start requiring a configuration file v2 (.readthedocs.yaml)
> starting on September 25, 2023. We are sending weekly notifications about this issue to all impacted users,
> as well as temporary build failures (brownouts) as the date approaches for those who haven't migrated their projects.